### PR TITLE
feat(kno-1271): connect projects with Slack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ KNOCK_API_KEY=<Knock server api key>
 # Required for Knock's notification React feed component to render correctly
 BLITZ_PUBLIC_KNOCK_CLIENT_ID=<Knock client key>
 BLITZ_PUBLIC_KNOCK_FEED_ID=<Knock in app feed channel id>
+
+# For Slack notifications
+BLITZ_PUBLIC_SLACK_CLIENT_ID=<Slack client id>
+SLACK_CLIENT_SECRET=<Slack app client secrent>
+BLITZ_PUBLIC_SLACK_REDIRECT_URI=<Slack redirect URI>
+KNOCK_SLACK_CHANNEL_ID=<id of a Slack channel in Knock>
 ```
 
 Ensure the `.env.test.local` file has required environment variables:
@@ -54,6 +60,12 @@ Ensure the `.env.test.local` file has required environment variables:
 ```
 DATABASE_URL=postgresql://<YOUR_DB_USERNAME>@localhost:5432/example-collaboration-app_test
 ```
+
+## Slack notifications
+
+In order for Slack notifications to work, you will need to expose an endpoint that Slack can access
+as part of the OAuth workflow. An easy way of doing this is installing [ngrok](https://ngrok.com/) and creating a public tunnel
+to your local web server.
 
 ## Commands
 

--- a/app/api/slack-cb.ts
+++ b/app/api/slack-cb.ts
@@ -1,0 +1,79 @@
+import { BlitzApiRequest, BlitzApiResponse, NotFoundError } from "blitz"
+import db from "db"
+import axios from "axios"
+import { URLSearchParams } from "url"
+import { Knock } from "@knocklabs/node"
+
+const knockClient = new Knock(process.env.KNOCK_API_KEY)
+
+const SLACK_ACCESS_ENDPOINT = "https://slack.com/api/oauth.v2.access"
+
+const handler = async (req: BlitzApiRequest, res: BlitzApiResponse) => {
+  const { code, state } = req.query
+  const { projectId } = JSON.parse(state as string)
+
+  const params = new URLSearchParams({
+    client_id: process.env.BLITZ_PUBLIC_SLACK_CLIENT_ID,
+    client_secret: process.env.SLACK_CLIENT_SECRET,
+    redirect_uri: process.env.BLITZ_PUBLIC_SLACK_REDIRECT_URI,
+    code,
+  } as Record<string, string>)
+  const accessTokenResponse = await axios.request({
+    method: "POST",
+    url: SLACK_ACCESS_ENDPOINT,
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    data: params.toString(),
+  })
+
+  if (accessTokenResponse.data.ok) {
+    const { url, channel } = accessTokenResponse.data.incoming_webhook
+
+    const project = await db.project.findFirst({
+      where: {
+        id: projectId,
+      },
+      include: {
+        workspace: true,
+      },
+    })
+
+    if (project) {
+      await db.project.update({
+        where: { id: project.id },
+        data: {
+          slackChannel: channel,
+        },
+      })
+
+      // After the user has selected which channel in Slack the project will be connected to, we set
+      // it as an object on Knock's side
+      await knockClient.objects.set("projects", `${project.id}`, {
+        name: project.name,
+      })
+
+      // Once the the object is present on Knock we set the incoming webhook url on its channel
+      // data for the Slack channel in Knock.
+      // Now that the project is mapped to an object in Knock we can trigger workflows and add it
+      // as a recipient. When the workflow reaches a Slack step and the object is a recipient, Knock
+      // will use the object's channel data to send the notification to the connected Slack channel.
+      await knockClient.objects.setChannelData(
+        "projects",
+        `${project.id}`,
+        process.env.KNOCK_SLACK_CHANNEL_ID!,
+        {
+          connections: [
+            {
+              incoming_webhook: { url },
+            },
+          ],
+        }
+      )
+
+      res.redirect(`/${project.workspace.slug}/${projectId}`).end()
+    } else {
+      return new NotFoundError()
+    }
+  }
+}
+
+export default handler

--- a/app/pages/[slug]/[projectId]/index.tsx
+++ b/app/pages/[slug]/[projectId]/index.tsx
@@ -2,6 +2,7 @@ import { BlitzPage, useRouter, useParam, useQuery, useMutation, Link, Routes } f
 import { useEffect, useState, useRef, Suspense } from "react"
 
 import Layout from "app/core/components/Layout"
+import AddSlackBtn from "app/projects/components/AddSlackBtn"
 import getProject from "app/projects/queries/getProject"
 import createAsset from "app/assets/mutations/createAsset"
 import { Form } from "app/core/components/Form"
@@ -48,12 +49,19 @@ const ProjectPageComponent = () => {
       <>
         <Flex flex={1} height="100%">
           <Box p={6} width="100%" position="relative">
-            <Heading size="lg" mb={6}>
-              {project.name}
+            <Flex alignItems="center" mb={6}>
+              <Heading size="lg">{project.name}</Heading>
               <Button ml={4} onClick={onOpen}>
                 Create asset
               </Button>
-            </Heading>
+              {project.slackChannel ? (
+                <Text ml="auto" fontWeight="bold">
+                  Connected to: {project.slackChannel}
+                </Text>
+              ) : (
+                <AddSlackBtn projectId={project.id} />
+              )}
+            </Flex>
 
             <Flex>
               {project.assets?.map((asset) => (

--- a/app/projects/components/AddSlackBtn.tsx
+++ b/app/projects/components/AddSlackBtn.tsx
@@ -1,0 +1,58 @@
+const SLACK_AUTHORIZE_URL = "https://slack.com/oauth/v2/authorize"
+
+const AddSlackBtn = ({ projectId }) => {
+  const params = new URLSearchParams({
+    redirect_uri: process.env.BLITZ_PUBLIC_SLACK_REDIRECT_URI,
+    state: JSON.stringify({ projectId }),
+    client_id: process.env.BLITZ_PUBLIC_SLACK_CLIENT_ID,
+    scope: "incoming-webhook",
+  } as Record<string, string>)
+
+  // Generated with https://api.slack.com/docs/slack-button
+  const linkStyles = {
+    alignItems: "center",
+    color: "#000",
+    backgroundColor: "#fff",
+    border: "1px solid #ddd",
+    borderRadius: "4px",
+    display: "inline-flex",
+    fontFamily: "Lato, sans-serif",
+    fontSize: "14px",
+    fontWeight: "600",
+    height: "44px",
+    justifyContent: "center",
+    textDecoration: "none",
+    width: "204px",
+    marginLeft: "auto",
+  }
+
+  return (
+    <a href={`${SLACK_AUTHORIZE_URL}?${params}`} style={linkStyles}>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        style={{ height: "16px", width: "16px", marginRight: "12px" }}
+        viewBox="0 0 122.8 122.8"
+      >
+        <path
+          d="M25.8 77.6c0 7.1-5.8 12.9-12.9 12.9S0 84.7 0 77.6s5.8-12.9 12.9-12.9h12.9v12.9zm6.5 0c0-7.1 5.8-12.9 12.9-12.9s12.9 5.8 12.9 12.9v32.3c0 7.1-5.8 12.9-12.9 12.9s-12.9-5.8-12.9-12.9V77.6z"
+          fill="#e01e5a"
+        ></path>
+        <path
+          d="M45.2 25.8c-7.1 0-12.9-5.8-12.9-12.9S38.1 0 45.2 0s12.9 5.8 12.9 12.9v12.9H45.2zm0 6.5c7.1 0 12.9 5.8 12.9 12.9s-5.8 12.9-12.9 12.9H12.9C5.8 58.1 0 52.3 0 45.2s5.8-12.9 12.9-12.9h32.3z"
+          fill="#36c5f0"
+        ></path>
+        <path
+          d="M97 45.2c0-7.1 5.8-12.9 12.9-12.9s12.9 5.8 12.9 12.9-5.8 12.9-12.9 12.9H97V45.2zm-6.5 0c0 7.1-5.8 12.9-12.9 12.9s-12.9-5.8-12.9-12.9V12.9C64.7 5.8 70.5 0 77.6 0s12.9 5.8 12.9 12.9v32.3z"
+          fill="#2eb67d"
+        ></path>
+        <path
+          d="M77.6 97c7.1 0 12.9 5.8 12.9 12.9s-5.8 12.9-12.9 12.9-12.9-5.8-12.9-12.9V97h12.9zm0-6.5c-7.1 0-12.9-5.8-12.9-12.9s5.8-12.9 12.9-12.9h32.3c7.1 0 12.9 5.8 12.9 12.9s-5.8 12.9-12.9 12.9H77.6z"
+          fill="#ecb22e"
+        ></path>
+      </svg>
+      Add to Slack
+    </a>
+  )
+}
+
+export default AddSlackBtn

--- a/db/migrations/20220510173655_add_slack_channel_to_projects/migration.sql
+++ b/db/migrations/20220510173655_add_slack_channel_to_projects/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Project" ADD COLUMN     "slackChannel" TEXT;

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -92,15 +92,16 @@ model Workspace_seat {
 }
 
 model Project {
-  id          Int              @id @default(autoincrement())
-  createdAt   DateTime         @default(now())
-  updatedAt   DateTime         @updatedAt
-  name        String
-  workspace   Workspace        @relation(fields: [workspaceId], references: [id])
-  workspaceId Int
-  members     Project_member[]
-  assets      Asset[]
-  comments    Comment[]
+  id           Int              @id @default(autoincrement())
+  createdAt    DateTime         @default(now())
+  updatedAt    DateTime         @updatedAt
+  name         String
+  workspace    Workspace        @relation(fields: [workspaceId], references: [id])
+  workspaceId  Int
+  slackChannel String?
+  members      Project_member[]
+  assets       Asset[]
+  comments     Comment[]
 }
 
 model Project_member {

--- a/package.json
+++ b/package.json
@@ -24,12 +24,13 @@
     ]
   },
   "dependencies": {
-    "@knocklabs/node": "0.4.3",
+    "@knocklabs/node": "0.4.4",
     "@knocklabs/react-notification-feed": "0.5.9",
     "@chakra-ui/react": "1.8.8",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
     "@prisma/client": "3.12.0",
+    "axios": "^0.27.2",
     "blitz": "0.45.4",
     "formik": "2.2.9",
     "framer-motion": "^5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1592,10 +1592,10 @@
     phoenix "1.5.8"
     zustand "^3.5.10"
 
-"@knocklabs/node@0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@knocklabs/node/-/node-0.4.3.tgz#d89c0f748fdbe9344761c02e87e69af48b1888dc"
-  integrity sha512-+bSu+lwLTinArQIkVtg4gPQa2L5eKP734FgI1MnVxsDRfQqCxS/xMGsr/1wEDbVrhoDG56zBz9xT+Bn4giCzyg==
+"@knocklabs/node@0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@knocklabs/node/-/node-0.4.4.tgz#4fb481b7926d753713f580e364cfb157f369c1c0"
+  integrity sha512-T47BxKvrPZig3FXED/2zEfvwPl3brrntCvLqgupNfKhNAyzHcqNUAer3JCgaqqypdS1kzk9K8xXqETLYLc6KEw==
   dependencies:
     axios "^0.21.1"
 
@@ -2931,6 +2931,14 @@ axios@^0.21.1, axios@^0.21.4:
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
     follow-redirects "^1.14.0"
+
+axios@^0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
+  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+  dependencies:
+    follow-redirects "^1.14.9"
+    form-data "^4.0.0"
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -5139,6 +5147,11 @@ follow-redirects@^1.14.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
   integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
 
+follow-redirects@^1.14.9:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.0.tgz#06441868281c86d0dda4ad8bdaead2d02dca89d4"
+  integrity sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -5153,6 +5166,15 @@ form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
   integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"


### PR DESCRIPTION
Add slack support to projects
Once a project is connected with a channel, the `new-comment` workflow should send a notification to the configured slack channel (will record a Loom video of this)