### PR TITLE
comment out notif prefs modal

### DIFF
--- a/app/core/components/Layout.tsx
+++ b/app/core/components/Layout.tsx
@@ -40,11 +40,11 @@ const Layout: React.FC<Props> = ({ children }) => {
 
   return (
     <Flex flexDirection="column" height="100%">
-      <NotificationPreferencesModal
+      {/* <NotificationPreferencesModal
         user={user}
         isOpen={isSettingsModalOpen}
         onClose={onCloseSettingsModal}
-      />
+      /> */}
       <Flex
         as="header"
         alignItems="center"


### PR DESCRIPTION
This PR removes the notification preferences modal component as the example app currently won't run with it in place. I'll file a separate ticket for us to come back and fix this. 