### PR TITLE
chore: add archive notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 ## Archive notice
 As of March 2024, this repository has been moved to a read-only archive. It's still usable and contains useful information, but we'll be porting this application to a newer version of Next.js in the very near future. In the meantime, you can check out the [example apps section](https://docs.knock.app/getting-started/example-app) of the Knock docs for a list of our example apps.
 
+## About
+
 This example app uses [Knock](https://knock.app) to power cross channel notifications via email, an in-app feed, and Slack inside of a full-stack Node application, written in [Blitz.js](https://blitzjs.com/). It uses the [Knock Node SDK](https://github.com/knocklabs/knock-node) and [React in-app feed components](https://github.com/knocklabs/react-notification-feed).
 
 You can read more about this example app [in the Knock documentation](https://docs.knock.app/getting-started/example-app#nodejs-example-app).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # **Knock + Node.js example app**
 
+## Archive notice
+As of March 2024, this repository has been moved to a read-only archive. It's still usable and contains useful information, but we'll be porting this application to a newer version of Next.js in the very near future. In the meantime, you can check out the [example apps section](https://docs.knock.app/getting-started/example-app) of the Knock docs for a list of our example apps.
+
 This example app uses [Knock](https://knock.app) to power cross channel notifications via email, an in-app feed, and Slack inside of a full-stack Node application, written in [Blitz.js](https://blitzjs.com/). It uses the [Knock Node SDK](https://github.com/knocklabs/knock-node) and [React in-app feed components](https://github.com/knocklabs/react-notification-feed).
 
 You can read more about this example app [in the Knock documentation](https://docs.knock.app/getting-started/example-app#nodejs-example-app).


### PR DESCRIPTION
I spent a bit of time trying to implement our new packages (node, client, react) without updating major versions of the largest dependencies (Blitz 2.x as current vs 0.45.x, for ex.), and was still running into issues around the node V16 to v18 move, even when manually setting: `NODE_OPTIONS=--openssl-legacy-provider`.

Since we have already stubbed out scope on porting the Collab.io to vanilla Next.js in the 'New Example App' roadmap item, we're going to archive this repo and prioritize that port over the next few weeks. This PR adds an archive notice to the README, I'll actually archive the repo once we merge this update. 